### PR TITLE
fix: todo comments rule cant be disabled closes #7

### DIFF
--- a/src/rules/document-todos.ts
+++ b/src/rules/document-todos.ts
@@ -16,9 +16,9 @@ const value = createRule<Record<string, string>[], string>({
                 const comments = sourceCode.getAllComments()
 
                 for (const comment of comments) {
-                    const isTodo = comment.value.toLowerCase().includes('todo')
-                    const isFixme = comment.value.toLowerCase().includes('fixme')
-                    const hasLink = comment.value.toLowerCase().includes(url.toLowerCase())
+                    const isTodo = comment.value.includes('TODO:')
+                    const isFixme = comment.value.includes('FIXME:')
+                    const hasLink = comment.value.includes(url.toLowerCase())
 
                     // Valid todo/fixme comment
                     if ((isTodo || isFixme) && hasLink) {

--- a/src/tests/tsx/rules/document-todos.test.ts
+++ b/src/tests/tsx/rules/document-todos.test.ts
@@ -153,6 +153,11 @@ const Component = () => {
     ],
     valid: [
         {
+            code: '// some random comment that contains todo and fixme:',
+            filename: TSX_FILE_PATH,
+            options,
+        },
+        {
             code: `
 const Component = () => {
     return (


### PR DESCRIPTION
The rule now expects todo and fixme comments to be written in a standard way aka

`TODO: something`
`FIXME: something`